### PR TITLE
fix homepage ssg

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,21 +18,18 @@ import { createSSGHelpers } from "@trpc/react/ssg";
 import superjson from "superjson";
 import { trpc } from "@/utils/trpc";
 
+const getHomepageEventsQ: ["events.get-all", { unlisted: false }] = [
+  "events.get-all",
+  { unlisted: false },
+];
+
 const Home: NextPage = () => {
   const router = useRouter();
   const newsletterRef = useRef<HTMLDivElement>(null);
   const plausible = usePlausible();
-  const q = trpc.useQuery(
-    [
-      "events.get-all",
-      {
-        unlisted: false,
-      },
-    ],
-    {
-      staleTime: Infinity,
-    }
-  );
+  const q = trpc.useQuery(getHomepageEventsQ, {
+    staleTime: Infinity,
+  });
 
   if (!q.data) {
     return <div>loading</div>;
@@ -101,7 +98,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     transformer: superjson,
   });
 
-  await ssg.fetchQuery("events.get-all");
+  await ssg.fetchQuery(...getHomepageEventsQ);
 
   // Make sure to return { props: { trpcState: ssg.dehydrate() } }
   return {


### PR DESCRIPTION
A different tRPC query was being used in getStaticProps and in the homepage components, so tRPC failed to use it and fallback to running client-side.